### PR TITLE
Implement private comment + User can join the meeting (close issue #12)

### DIFF
--- a/snumeeting-front/src/app/meeting-detail/meeting-detail.component.html
+++ b/snumeeting-front/src/app/meeting-detail/meeting-detail.component.html
@@ -22,24 +22,32 @@
      <!--Create comment-->
      <input [(ngModel)]="newComment" style="width:400px;">
      <button (click)="createComment(newComment)" class="btn btn-primary btn-sm" id="create-comment-button">CREATE</button>
+     <input type="checkbox" class="checkbox-inline" [checked]="isPrivate" (click)="changePrivateMode(true)"> Private
      <li *ngFor="let comment of comments">
-       <!--Author of the comment-->
-       <span style="font-weight:bold">{{ comment.author.name }}</span>
-       <!--Content of the comment-->
-       :
-       <span *ngIf="selectedComment!==comment;else edit_mode">
-        {{comment.content}}
-         <!--Edit / Delete button-->
-      <span *ngIf="currentUser && (currentUser.id===comment.author.id)">
-        <button (click)="toEditMode(comment)" class="btn btn-primary btn-sm" style="margin-left:20px;" id="edit-comment-button">EDIT</button>
-        <button (click)="deleteComment(comment)" class="btn btn-primary btn-sm" id="delete-comment-button">DELETE</button>
-      </span>
-    </span>
+       <span *ngIf="comment.publicity || currentUser.id===selectedMeeting.author.id || currentUser.id===comment.author.id; else private_comment">
+         <!--Author of the comment-->
+         <span style="font-weight:bold">{{ comment.author.name }}</span>
+         <!--Content of the comment-->
+         :
+         <span *ngIf="selectedComment!==comment;else edit_mode">
+            {{comment.content}}
+             <!--Edit / Delete button-->
+            <span *ngIf="currentUser && (currentUser.id===comment.author.id)">
+              <button (click)="toEditMode(comment)" class="btn btn-primary btn-sm" style="margin-left:20px;" id="edit-comment-button">EDIT</button>
+              <button (click)="deleteComment(comment)" class="btn btn-primary btn-sm" id="delete-comment-button">DELETE</button>
+            </span>
+          </span>
 
-       <ng-template #edit_mode>
-         <input [(ngModel)]="comment.content">
-         <button (click)="editComment(comment)" class="btn btn-primary btn-sm" id="update-button">UPDATE</button>
-         <button (click)="cancleEditMode(comment)" class="btn btn-primary btn-sm" id="cancle-edit-button">CANCLE</button>
+         <ng-template #edit_mode>
+           <input [(ngModel)]="comment.content">
+           <button (click)="editComment(comment)" class="btn btn-primary btn-sm" id="update-button">UPDATE</button>
+           <button (click)="cancleEditMode(comment)" class="btn btn-primary btn-sm" id="cancle-edit-button">CANCLE</button>
+           <input type="checkbox" class="checkbox-inline" [checked]="!comment.publicity" (click)="changePrivateMode(false)"> Private
+         </ng-template>
+       </span>
+
+       <ng-template #private_comment>
+         <label style="color:royalblue">Private comment</label>
        </ng-template>
      </li>
    </div><br>

--- a/snumeeting-front/src/app/meeting-detail/meeting-detail.component.html
+++ b/snumeeting-front/src/app/meeting-detail/meeting-detail.component.html
@@ -7,6 +7,9 @@
  <div class="container center-block" style="width:600px;">
 
    <h3>Meeting</h3>
+   <button *ngIf="currentUser && selectedMeeting" (click)="joinMeeting()" style="float:right" class="btn btn-primary btn-primary">
+     JOIN
+   </button>
 
    <div *ngIf="selectedMeeting">
      <span style="font-weight: bold">title: </span> {{ selectedMeeting.title }}<br>

--- a/snumeeting-front/src/app/meeting-detail/meeting-detail.component.ts
+++ b/snumeeting-front/src/app/meeting-detail/meeting-detail.component.ts
@@ -119,7 +119,20 @@ export class MeetingDetailComponent implements OnInit {
     } else {        // edit mode
       this.isPrivate_edit = !this.isPrivate_edit;
     }
+  }
 
+  joinMeeting(): void {
+    if (this.selectedMeeting.members.find(member => member.id === this.currentUser.id)) {
+      alert('You have already joined this meeting!');
+      return;
+    }
+    if (this.selectedMeeting.members.length === this.selectedMeeting.max_member) {
+      alert('This meeting is already full! :(');
+      return;
+    }
+    this.meetingService.joinMeeting(this.selectedMeeting.id, this.currentUser.id);
+    this.selectedMeeting.members.push(this.currentUser);
+    alert('Welcome!');
   }
 
 }

--- a/snumeeting-front/src/app/meeting-detail/meeting-detail.component.ts
+++ b/snumeeting-front/src/app/meeting-detail/meeting-detail.component.ts
@@ -30,6 +30,8 @@ export class MeetingDetailComponent implements OnInit {
   private selectedComment: Comment = null;   // Comment to be edited
 
   @Input() private newComment: string = null;
+  private isPrivate = false;
+  private isPrivate_edit = false;
 
   ngOnInit() {
     this.route.params.subscribe(params => {
@@ -49,7 +51,7 @@ export class MeetingDetailComponent implements OnInit {
 
 
   goBack(): void {
-    this.router.navigate(['/meeting']);   // TODO: meeting list URL?
+    this.router.navigate(['/meeting']);
   }
 
   // edit(): void {
@@ -58,17 +60,18 @@ export class MeetingDetailComponent implements OnInit {
   //
   delete(): void {
     this.meetingService.deleteMeeting(this.selectedMeeting.id);
-    this.router.navigate(['/meeting']);   // TODO: meeting list URL?
+    this.router.navigate(['/meeting']);
   }
 
   createComment(content: string): void {
     if (this.newComment !== null) {
       let comment;
-      this.commentService.createComment(this.selectedMeeting.id, this.currentUser, content, true)
+      this.commentService.createComment(this.selectedMeeting.id, this.currentUser, content, !this.isPrivate)
         .then(res => {
           comment = res;
           this.comments.push(comment);
           this.newComment = null;
+          this.isPrivate = false;
         });
     }
   }
@@ -83,7 +86,7 @@ export class MeetingDetailComponent implements OnInit {
 
   editComment(comment: Comment): void {
     const targetIdx = this.comments.indexOf(comment);
-    this.commentService.editComment(comment).then(modifiedComment => {
+    this.commentService.editComment(comment, !this.isPrivate_edit).then(modifiedComment => {
       this.comments[targetIdx] = modifiedComment;
       this.selectedComment = null;
     });
@@ -108,6 +111,15 @@ export class MeetingDetailComponent implements OnInit {
   signOut(): void {
     this.userService.signOut();
     this.router.navigate(['/']);
+  }
+
+  changePrivateMode(create: boolean): void {
+    if (create) {   // create mode
+      this.isPrivate = !this.isPrivate;
+    } else {        // edit mode
+      this.isPrivate_edit = !this.isPrivate_edit;
+    }
+
   }
 
 }

--- a/snumeeting-front/src/app/services/comment.service.spec.ts
+++ b/snumeeting-front/src/app/services/comment.service.spec.ts
@@ -130,7 +130,7 @@ describe('CommentService', () => {
       service.getComment(3)
         .then(comment => {
           comment.content = 'New content';
-          service.editComment(comment).then(modifiedComment => {
+          service.editComment(comment, true).then(modifiedComment => {
             console.log(modifiedComment);
             expect(modifiedComment.content).toBe('New content');
           });

--- a/snumeeting-front/src/app/services/comment.service.ts
+++ b/snumeeting-front/src/app/services/comment.service.ts
@@ -55,10 +55,10 @@ export class CommentService {
       .catch(this.handleError);
   }
 
-  editComment(editedComment: Comment): Promise<Comment> {
+  editComment(editedComment: Comment, publicity: boolean): Promise<Comment> {
     const url = `${this.commentsUrl}/${editedComment.id}`;
     return this.http.put(url,
-                         JSON.stringify({content: editedComment.content, publicity: editedComment.publicity}),
+                         JSON.stringify({content: editedComment.content, publicity: publicity}),
                  { headers: headerWithCSRF() })
       .toPromise()
       .then(() => editedComment)

--- a/snumeeting-front/src/app/services/meeting.service.ts
+++ b/snumeeting-front/src/app/services/meeting.service.ts
@@ -95,7 +95,7 @@ export class MeetingService {
         description: editedMeeting.description,
         location: editedMeeting.location,
         max_member: editedMeeting.max_member,
-        subject_id: editedMeeting.subject.id
+        subject_id: editedMeeting.subject.id,
       }),
       {headers: headerWithCSRF()})
       .toPromise()
@@ -106,6 +106,15 @@ export class MeetingService {
   deleteMeeting(id: number): Promise<Meeting> {
     const url = `${this.meetingsUrl}/${id}`;
     return this.http.delete(url, {headers: headerWithCSRF()})
+      .toPromise()
+      .then(() => null)
+      .catch(this.handleError);
+  }
+
+  joinMeeting(meeting_id: number, user_id: number) {
+    const url = `api/joinMeeting`;
+    return this.http.put(url,
+      JSON.stringify({meeting_id: meeting_id, user_id: user_id}), {headers: headerWithCSRF()})
       .toPromise()
       .then(() => null)
       .catch(this.handleError);

--- a/snumeeting_back/snumeeting/tests.py
+++ b/snumeeting_back/snumeeting/tests.py
@@ -738,7 +738,28 @@ class SnuMeetingTestCase(TestCase):
       self.assertEqual(result['username'], 'test')
       self.assertEqual(result['name'], 'test')
 
+  def test_joinMeeting(self):
+      response = self.client.put('/api/joinMeeting', json.dumps({'meeting_id':1, 'user_id':2}), content_type='application/json')
 
+      response = self.client.get('/api/meeting/1')
+      result = json.loads(response.content.decode())
+      self.assertEqual(len(result['members']), 3)
 
+      # Non existing meeting
+      response = self.client.put('/api/joinMeeting', json.dumps({'meeting_id':10, 'user_id':2}), content_type='application/json')
+      self.assertEqual(response.status_code, 404)
 
+      # Non existing user
+      response = self.client.put('/api/joinMeeting', json.dumps({'meeting_id':1, 'user_id':12}), content_type='application/json')
+      self.assertEqual(response.status_code, 404)
+
+      # Not allowed methods
+      response = self.client.get('/api/joinMeeting')
+      self.assertEqual(response.status_code, 405)
+
+      response = self.client.post('/api/joinMeeting')
+      self.assertEqual(response.status_code, 405)
+
+      response = self.client.delete('/api/joinMeeting')
+      self.assertEqual(response.status_code, 405)
 

--- a/snumeeting_back/snumeeting/urls.py
+++ b/snumeeting_back/snumeeting/urls.py
@@ -4,6 +4,7 @@ from .views import meetingList, meetingDetail, meetingComment, commentList, comm
 from .views import interestList, subjectList, subjectDetail, collegeList, collegeDetail
 from .views import token
 from .views import searchMeeting_title, searchMeeting_author, searchMeeting_subject
+from .views import joinMeeting
 
 urlpatterns = [
   url('^token$', token, name='token'),
@@ -26,5 +27,6 @@ urlpatterns = [
   url(r'^meeting/search/title/(?P<query>.+)$', searchMeeting_title, name='searchMeeting_title'),
   url(r'^meeting/search/author/(?P<query>.+)$', searchMeeting_author, name='searchMeeting_author'),
   url(r'^meeting/search/subject/(?P<subject_id>[0-9]+)(_(?P<query>.+))?$', searchMeeting_subject, name='searchMeeting_subject'),
+  url(r'^joinMeeting$', joinMeeting, name='joinMeeting'),
 ]
 

--- a/snumeeting_back/snumeeting/views.py
+++ b/snumeeting_back/snumeeting/views.py
@@ -405,4 +405,21 @@ def searchMeeting_subject(request, subject_id, query):
 
   return JsonResponse(result, safe=False)
 
+def joinMeeting(request):
+  if request.method == 'PUT':
+    des_req = json.loads(request.body.decode())
+    meeting_id = des_req['meeting_id']
+    user_id = des_req['user_id']
+    try:
+      meeting = Meeting.objects.get(id=meeting_id)
+      user = Ex_User.objects.get(id=user_id)
+      meeting.members.add(user)
+      meeting.save()
+    except Meeting.DoesNotExist:
+      return HttpResponseNotFound()
+    except Ex_User.DoesNotExist:
+      return HttpResponseNotFound()
+    return HttpResponse(status=204)
+  else:
+    return HttpResponseNotAllowed(['PUT'])
 


### PR DESCRIPTION
This PR enables private/public option when user generates a comment. 
When the comment is created in private option, only the author of the posting(meeting) and author of the comment can see it.

And This PR also enables user to join the meeting.
For this, joinMeeting() has been added to `views.py`, and testing code for it is also included.