### PR TITLE
[MINOR] Fix bug on changing password

### DIFF
--- a/snumeeting-front/src/app/edit-profile/edit-profile.component.ts
+++ b/snumeeting-front/src/app/edit-profile/edit-profile.component.ts
@@ -66,6 +66,10 @@ export class EditProfileComponent implements OnInit {
   }
 
   editProfile(password: string, passwordCheck: string, name: string) {
+    if (password === '') {
+      alert('Please enter a new password!');
+      return;
+    }
     if (password === passwordCheck) {
       var selectedSubjects: Subject[] = [];
 


### PR DESCRIPTION
This PR fix bug that when user does not enter new password on edit profile page, the password will be set to empty string. From this PR, user should see an alert asking to enter a new password.